### PR TITLE
Hotfixes #1 added, details written in issues log

### DIFF
--- a/ft_bzero.c
+++ b/ft_bzero.c
@@ -14,7 +14,7 @@
 
 void	ft_bzero(void *s, size_t n)
 {
-	char	*p;
+	unsigned char	*p;
 
 	p = s;
 	while (n--)

--- a/ft_lstmap.c
+++ b/ft_lstmap.c
@@ -16,12 +16,15 @@ t_list	*ft_lstmap(t_list *lst, void *(*f)(void *), void (*del)(void *))
 {
 	t_list	*map;
 	t_list	*node;
+	void	*content;
 
 	map = NULL;
 	while (lst)
 	{
-		node = ft_lstnew((*f)(lst->content));
-		if (!node)
+		content = (*f)(lst->content);
+		if (content)
+			node = ft_lstnew(content);
+		if (!content || !node)
 		{
 			ft_lstclear(&map, del);
 			return (NULL);

--- a/ft_memccpy.c
+++ b/ft_memccpy.c
@@ -16,8 +16,8 @@ void	*ft_memccpy(void *dest, const void *src, int c, size_t n)
 {
 	while (n--)
 	{
-		*(int *)dest = *(int *)src++;
-		if (*(int *)dest++ == c)
+		*(unsigned char *)dest = *(unsigned char *)src++;
+		if (*(unsigned char *)dest++ == c)
 			return (dest);
 	}
 	return (NULL);

--- a/ft_memcpy.c
+++ b/ft_memcpy.c
@@ -14,12 +14,12 @@
 
 void	*ft_memcpy(void	*dest, const void *src, size_t n)
 {
-	char	*ptr;
+	unsigned char	*ptr;
 
 	ptr = dest;
 	if (!src && !dest)
 		return (NULL);
 	while (n--)
-		*ptr++ = *(char *)src++;
+		*ptr++ = *(unsigned char *)src++;
 	return (dest);
 }

--- a/ft_memmove.c
+++ b/ft_memmove.c
@@ -23,12 +23,12 @@ void	*ft_memmove(void *dest, const void *src, size_t n)
 	{
 		while (i < n)
 		{
-			((char *)dest)[i] = ((char *)src)[i];
+			((unsigned char *)dest)[i] = ((unsigned char *)src)[i];
 			++i;
 		}
 	}
 	else
 		while (n--)
-			((char *)dest)[n] = ((char *)src)[n];
+			((unsigned char *)dest)[n] = ((unsigned char *)src)[n];
 	return (dest);
 }

--- a/ft_memset.c
+++ b/ft_memset.c
@@ -15,6 +15,6 @@
 void	*ft_memset(void *s, int c, size_t n)
 {
 	while (n--)
-		((char *)s)[n] = (unsigned char) c;
+		((unsigned char *)s)[n] = (unsigned char) c;
 	return (s);
 }

--- a/ft_putchar_fd.c
+++ b/ft_putchar_fd.c
@@ -12,7 +12,7 @@
 
 #include "libft.h"
 
-void	ft_putchar_fd(char c, int fd)
+ssize_t	ft_putchar_fd(char c, int fd)
 {
-	write(fd, &c, 1);
+	return (write(fd, &c, 1));
 }

--- a/ft_putendl_fd.c
+++ b/ft_putendl_fd.c
@@ -12,8 +12,12 @@
 
 #include "libft.h"
 
-void	ft_putendl_fd(char *s, int fd)
+ssize_t	ft_putendl_fd(char *s, int fd)
 {
-	ft_putstr_fd(s, fd);
-	ft_putchar_fd('\n', fd);
+	ssize_t	i;
+
+	i = 0;
+	i = ft_putstr_fd(s, fd);
+	i += ft_putchar_fd('\n', fd);
+	return (i);
 }

--- a/ft_putnbr_fd.c
+++ b/ft_putnbr_fd.c
@@ -12,29 +12,33 @@
 
 #include "libft.h"
 
-static void	ft_putn(int n, int fd)
+static ssize_t	ft_putn(int n, int fd)
 {
+	ssize_t	c;
+
+	c = 0;
 	if (!n)
-		return ;
+		return (0);
 	if (n < 0)
 	{
-		ft_putchar_fd('-', fd);
+		c += ft_putchar_fd('-', fd);
 		if (n < -9)
-			ft_putn(n / 10 * -1, fd);
-		ft_putchar_fd(n % 10 * -1 + '0', fd);
+			c += ft_putn(n / 10 * -1, fd);
+		c += ft_putchar_fd(n % 10 * -1 + '0', fd);
 	}
 	else
 	{
 		if (n > 9)
-			ft_putn(n / 10, fd);
-		ft_putchar_fd(n % 10 + '0', fd);
+			c += ft_putn(n / 10, fd);
+		c += ft_putchar_fd(n % 10 + '0', fd);
 	}
+	return (c);
 }
 
-void	ft_putnbr_fd(int n, int fd)
+ssize_t	ft_putnbr_fd(int n, int fd)
 {
 	if (!n)
-		ft_putchar_fd('0', fd);
+		return (ft_putchar_fd('0', fd));
 	else
-		ft_putn(n, fd);
+		return (ft_putn(n, fd));
 }

--- a/ft_putstr_fd.c
+++ b/ft_putstr_fd.c
@@ -12,10 +12,10 @@
 
 #include "libft.h"
 
-void	ft_putstr_fd(char *s, int fd)
+ssize_t	ft_putstr_fd(char *s, int fd)
 {
 	size_t	len;
 
 	len = ft_strlen(s);
-	write(fd, s, len);
+	return (write(fd, s, len));
 }

--- a/libft.h
+++ b/libft.h
@@ -64,10 +64,10 @@ char	*ft_itoa(int n);
 char	*ft_uitoa(unsigned int n);
 char	*ft_strmapi(const char *s, char (*f)(unsigned int, char));
 
-void	ft_putchar_fd(char c, int fd);
-void	ft_putstr_fd(char *s, int fd);
-void	ft_putendl_fd(char *s, int fd);
-void	ft_putnbr_fd(int n, int fd);
+ssize_t	ft_putchar_fd(char c, int fd);
+ssize_t	ft_putstr_fd(char *s, int fd);
+ssize_t	ft_putendl_fd(char *s, int fd);
+ssize_t	ft_putnbr_fd(int n, int fd);
 
 t_list	*ft_lstnew(void *content);
 void	ft_lstadd_front(t_list **lst, t_list *new);


### PR DESCRIPTION
1.     ft_bzero - change from char to unsigned char
2.     ft_lstmap - add null check for (*f) return before passing to ft_lstnew
3.     ft_memccpy - change from int to unsigned char casting
4.     ft_memcpy - change from char to unsigned char casting
5.     ft_memmove - change from char to unsigned char casting
6.     ft_memset - change from char to unsigned char casting
7.     ft_put* - change return type to ssize_t, return bytes printed